### PR TITLE
Make execution optional; add static execution check

### DIFF
--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -3,7 +3,9 @@
 - Filter input file list for .ipynb files
 - Check that the cells have been executed sequentially on a fresh kernel
 - Strip trailing whitespace from all code lines
-- Execute the notebook and fail if errors are encountered
+- Either:
+  - Execute the notebook and fail if errors are encountered
+  - Check that all code cells have been executed without error
 - Extract solution code and write a .py file with the solution
 - Replace solution cells with a "hint" image and a link to the solution code
 - Redirect Colab-inserted badges to the master branch
@@ -67,8 +69,8 @@ def main(arglist):
         exec_kws["kernel_name"] = os.environ["NB_KERNEL"]
 
     # Defer failures until after processing all notebooks
-    errors = {}
     notebooks = {}
+    errors = {}
 
     for nb_path in nb_paths:
 
@@ -89,20 +91,23 @@ def main(arglist):
         # Clean whitespace from all code cells
         clean_whitespace(nb)
 
-        # Run the notebook from top to bottom, catching errors
-        print(f"Executing {nb_path}")
-        executor = ExecutePreprocessor(**exec_kws)
-        try:
-            executor.preprocess(nb)
-        except Exception as err:
-            if args.raise_fast:
-                # Exit here (useful for debugging)
-                raise err
-            else:
-                # Log the error, but then continue
-                errors[nb_path] = err
+        # Ensure that we have an executed notebook, in one of two ways
+        if args.execute:
+            # Check dynamically by executing and reporting errors
+            print(f"Executing {nb_path}")
+            executor = ExecutePreprocessor(**exec_kws)
+            error = execute_notebook(executor, nb, args.raise_fast)
+        elif args.check_execution:
+            # Check statically by examining the cell outputs
+            print(f"Checking {nb_path} execution")
+            error = check_execution(nb, args.raise_fast)
         else:
+            error = None
+
+        if error is None:
             notebooks[nb_path] = nb
+        else:
+            errors[nb_path] = error
 
     if errors or args.check_only:
         exit(errors)
@@ -174,6 +179,43 @@ def main(arglist):
 
 
 # ------------------------------------------------------------------------------------ #
+
+def execute_notebook(executor, nb, raise_fast):
+    """Execute the notebook, returning errors to be handled."""
+    try:
+        executor.preprocess(nb)
+    except Exception as error:
+        if raise_fast:
+            # Exit here (useful for debugging)
+            raise error
+        else:
+            # Raise the error to be handled by the caller
+            return error
+
+
+def check_execution(nb, raise_fast):
+    """Check that all code cells with source have been executed without error."""
+    error = None
+    for cell in nb.get("cells", []):
+
+        # Only check code cells
+        if cell["cell_type"] != "code":
+            continue
+
+        if cell["source"] and cell["execution_count"] is None:
+            error = "Notebook has unexecuted code cell(s)."
+            if raise_fast:
+                raise RuntimeError(error)
+            break
+        else:
+            for output in cell["outputs"]:
+                if output["output_type"] == "error":
+                    error = "\n".join(output["traceback"])
+                    if raise_fast:
+                        raise RuntimeError("\n" + error)
+                    break
+
+    return error
 
 
 def extract_solutions(nb, nb_dir, nb_name):
@@ -399,22 +441,33 @@ def parse_args(arglist):
         help="File name(s) to process. Will filter for .ipynb extension."
     )
     parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Execute the notebook and fail if errors are encountered."
+    )
+    parser.add_argument(
+        "--check-execution",
+        action="store_true",
+        dest="check_execution",
+        help="Check that each code cell has been executed and did not error."
+    )
+    parser.add_argument(
+        "--allow-non-sequential",
+        action="store_false",
+        dest="require_sequential",
+        help="Don't fail if the notebook is not sequentially executed."
+    )
+    parser.add_argument(
         "--check-only",
         action="store_true",
         dest="check_only",
-        help="Only run QC checks; don't do post-processing"
+        help="Only run QC checks; don't do post-processing."
     )
     parser.add_argument(
         "--raise-fast",
         action="store_true",
         dest="raise_fast",
         help="Raise errors immediately rather than collecting and reporting."
-    )
-    parser.add_argument(
-        "--allow-non-sequential",
-        action="store_false",
-        dest="require_sequential",
-        help="Don't fail if the notebook is not sequentially executed"
     )
     return parser.parse_args(arglist)
 


### PR DESCRIPTION
This change to the CI workflow is intended to support cases where it is infeasible to execute tutorials as part of the build. For example, because the notebook requires a GPU.

It accomplishes this by adding a check to ensure that the notebook submitted to the CI system is in a clean executed state. This check asserts that:

- Execution prompts are in a sequentially increasing order from 1 to N
- All code cells have been executed
- No code cells have error outputs

These heuristics should catch most mistakes that production editors might be likely to make, and they allow the downstream CI processes (i.e. building the student versions) to succeed without needing to execute the notebook on the GitHub VM.

There is one situation I can think of that cannot be detected this way, which would be where an editor starts with an executed notebook and then changes the source code in existing cells without re-executing any of them. The notebook file format does not capture any metadata that would expose this operation, and it is possible that this could cause the notebook to fail for students in a way that the dynamic checks would have caught. Once notebooks have been pulled into the git repo, this should be relatively rare, as they'll be stored in an un-executed state.

There is another disadvantage relative to the dynamic checks (i.e. executing the notebooks in CI) which is that the build does not fail on cells that raise `NotImplementedError`, so incomplete exercises can be written without commenting-out code that depends on their completion. The static analysis code will also ignore cells with this error class in their outputs. But I do not know of a way to "Run all"  in Colab such that execution proceeds through exceptions (there are some vanilla Jupyter plugins that allow this). Supporting uncommented exercises in DL will require editors to run the notebooks in a piecewise fashion (i.e. "Run All" then "Run Below" after every error caused by an incomplete exercise), which would be pretty annoying.

Nevertheless, this presents a relatively simple solution to the problem of validating notebooks without executing them.

⚠️ Merging this PR will require a change in the main `course-content` repository to add the `--execute` flag to `process_notebooks.py` in the `.github/workflows/notebook-pr.yaml` file. It will also require modifying the DL version of the workflow to use the `--check-execution` flag instead. Currently the script does not require that you either execute OR check execution, so it's possible to run it without doing so, which would be somewhat dangerous. It could be possible to enforce that one of those options is activated, however.  ⚠️ 