### PR TITLE
Postprocess

### DIFF
--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -125,6 +125,8 @@ def main(arglist):
         for cell in nb.get("cells", []):
             if has_colab_badge(cell):
                 redirect_colab_badge_to_main_branch(cell)
+                # add kaggle badge
+                add_kaggle_badge(cell)
 
         # Ensure that Colab metadata dict exists and enforce some settings
         add_colab_metadata(nb, nb_name)
@@ -153,6 +155,8 @@ def main(arglist):
         for cell in student_nb.get("cells", []):
             if has_colab_badge(cell):
                 redirect_colab_badge_to_student_version(cell)
+                # add kaggle badge
+                add_kaggle_badge(cell)
 
         # Write the student version of the notebook
         student_nb_path = os.path.join(student_dir, nb_fname)
@@ -474,7 +478,16 @@ def test_redirect_colab_badge_to_student_version():
 
     assert cell["source"] == expected
 
-
+def add_kaggle_badge(cell):
+    """Add a kaggle badge if not exists."""
+    cell_text = cell["source"]
+    if len(cell_text) == 1:
+        badge_link = "https://kaggle.com/static/images/open-in-kaggle.svg"
+        service = "https://kaggle.com/kernels/welcome?src="
+        local_path = re.findall(r'(tutorials.+?\.ipynb)', cell_text)[0]
+        a = f"[![Kaggle]({badge_link})]({service}https://raw.githubusercontent.com/NeuromatchAcademy/{REPO}/{MAIN_BRANCH}/{local_path})"
+        cell_text.append(a)
+    
 def sequentially_executed(nb):
     """Return True if notebook appears freshly executed from top-to-bottom."""
     exec_counts = [

--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -136,15 +136,10 @@ def main(arglist):
         # Ensure that Colab metadata dict exists and enforce some settings
         add_colab_metadata(nb, nb_name)
 
-        # Clean the original notebook and save it to disk
+        # Clean the original notebook and save it to disk if it belongs to tutorials
         print(f"Writing complete notebook to {nb_path}")
         with open(nb_path, "w") as f:
-            if nb_path.startswith("tutorials"):
-               flag = True
-            elif nb_path.startswith("projects"):
-               flag = False
-            nb_clean = clean_notebook(nb, flag)
-            
+            nb_clean = clean_notebook(nb, clear_outputs=nb_path.startswith("tutorials"))
             nbformat.write(nb_clean, f)
 
         if nb_path.startswith("tutorials"):
@@ -303,7 +298,7 @@ def extract_solutions(nb, nb_dir, nb_name):
     return nb, static_images, solution_snippets
 
 
-def clean_notebook(nb, flag):
+def clean_notebook(nb, clear_outputs):
     """Remove cell outputs and most unimportant metadata."""
     # Always operate on a copy of the input notebook
     nb = deepcopy(nb)
@@ -340,9 +335,8 @@ def clean_notebook(nb, flag):
                 cell["metadata"].pop("id")
 
         if cell["cell_type"] == "code":
-            
-            if flag:
-                # Remove code cell outputs only in tutorials
+            # Remove code cell outputs only in notebooks under tutorials
+            if clear_outputs:
                 cell["outputs"] = []
 
             # Ensure that form cells are hidden by default

--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -136,7 +136,7 @@ def main(arglist):
         # Ensure that Colab metadata dict exists and enforce some settings
         add_colab_metadata(nb, nb_name)
 
-        # Clean the original notebook and save it to disk if it belongs to tutorials
+         # Write the original notebook back to disk, clearing outputs only for tutorials
         print(f"Writing complete notebook to {nb_path}")
         with open(nb_path, "w") as f:
             nb_clean = clean_notebook(nb, clear_outputs=nb_path.startswith("tutorials"))

--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -142,41 +142,44 @@ def main(arglist):
             nb_clean = clean_notebook(nb, clear_outputs=nb_path.startswith("tutorials"))
             nbformat.write(nb_clean, f)
 
-        if nb_path.startswith("tutorials"):
-            # Create subdirectories, if they don't exist
-            student_dir = make_sub_dir(nb_dir, "student")
-            static_dir = make_sub_dir(nb_dir, "static")
-            solutions_dir = make_sub_dir(nb_dir, "solutions")
+        # if the notebook is not in tutorials, skip the creation/update of the student, static, solutions directories
+        if not nb_path.startswith("tutorials"):
+          continue
+        
+        # Create subdirectories, if they don't exist
+        student_dir = make_sub_dir(nb_dir, "student")
+        static_dir = make_sub_dir(nb_dir, "static")
+        solutions_dir = make_sub_dir(nb_dir, "solutions")
 
-            # Generate the student version and save it to a subdirectory
-            print(f"Extracting solutions from {nb_path}")
-            processed = extract_solutions(nb, nb_dir, nb_name)
-            student_nb, static_images, solution_snippets = processed
+        # Generate the student version and save it to a subdirectory
+        print(f"Extracting solutions from {nb_path}")
+        processed = extract_solutions(nb, nb_dir, nb_name)
+        student_nb, static_images, solution_snippets = processed
 
-            # Loop through cells and point the colab badge at the student version
-            for cell in student_nb.get("cells", []):
-                if has_colab_badge(cell):
-                    redirect_colab_badge_to_student_version(cell)
+        # Loop through cells and point the colab badge at the student version
+        for cell in student_nb.get("cells", []):
+            if has_colab_badge(cell):
+                redirect_colab_badge_to_student_version(cell)
 
-            # Write the student version of the notebook
-            student_nb_path = os.path.join(student_dir, nb_fname)
-            print(f"Writing student notebook to {student_nb_path}")
-            with open(student_nb_path, "w") as f:
-                clean_student_nb = clean_notebook(student_nb)
-                nbformat.write(clean_student_nb, f)
+        # Write the student version of the notebook
+        student_nb_path = os.path.join(student_dir, nb_fname)
+        print(f"Writing student notebook to {student_nb_path}")
+        with open(student_nb_path, "w") as f:
+            clean_student_nb = clean_notebook(student_nb)
+            nbformat.write(clean_student_nb, f)
 
-            # Write the images extracted from the solution cells
-            print(f"Writing solution images to {static_dir}")
-            for fname, image in static_images.items():
-                fname = fname.replace("static", static_dir)
-                image.save(fname)
+        # Write the images extracted from the solution cells
+        print(f"Writing solution images to {static_dir}")
+        for fname, image in static_images.items():
+            fname = fname.replace("static", static_dir)
+            image.save(fname)
 
-            # Write the solution snippets
-            print(f"Writing solution snippets to {solutions_dir}")
-            for fname, snippet in solution_snippets.items():
-                fname = fname.replace("solutions", solutions_dir)
-                with open(fname, "w") as f:
-                    f.write(snippet)
+        # Write the solution snippets
+        print(f"Writing solution snippets to {solutions_dir}")
+        for fname, snippet in solution_snippets.items():
+            fname = fname.replace("solutions", solutions_dir)
+            with open(fname, "w") as f:
+                f.write(snippet)
 
     exit(errors)
 

--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -114,7 +114,7 @@ def main(arglist):
     if errors or args.check_only:
         exit(errors)
 
-    # Further filter the notebooks to run post-processing only on tutorials
+    # Further filter the notebooks to run post-processing only on tutorials and projects
     tuts_projs = {
         nb_path: nb
         for nb_path, nb in notebooks.items()
@@ -341,7 +341,7 @@ def clean_notebook(nb, flag='tutorials'):
         if cell["cell_type"] == "code":
             
             if flag == 'tutorials':
-                # Remove code cell outputs
+                # Remove code cell outputs only in tutorials
                 cell["outputs"] = []
 
             # Ensure that form cells are hidden by default

--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -140,9 +140,10 @@ def main(arglist):
         print(f"Writing complete notebook to {nb_path}")
         with open(nb_path, "w") as f:
             if nb_path.startswith("tutorials"):
-                nb_clean = clean_notebook(nb)
+               flag = True
             elif nb_path.startswith("projects"):
-                nb_clean = clean_notebook(nb, flag='projects')
+               flag = False
+            nb_clean = clean_notebook(nb, flag)
             
             nbformat.write(nb_clean, f)
 
@@ -302,7 +303,7 @@ def extract_solutions(nb, nb_dir, nb_name):
     return nb, static_images, solution_snippets
 
 
-def clean_notebook(nb, flag='tutorials'):
+def clean_notebook(nb, flag):
     """Remove cell outputs and most unimportant metadata."""
     # Always operate on a copy of the input notebook
     nb = deepcopy(nb)
@@ -340,7 +341,7 @@ def clean_notebook(nb, flag='tutorials'):
 
         if cell["cell_type"] == "code":
             
-            if flag == 'tutorials':
+            if flag:
                 # Remove code cell outputs only in tutorials
                 cell["outputs"] = []
 

--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -298,7 +298,7 @@ def extract_solutions(nb, nb_dir, nb_name):
     return nb, static_images, solution_snippets
 
 
-def clean_notebook(nb, clear_outputs):
+def clean_notebook(nb, clear_outputs=True):
     """Remove cell outputs and most unimportant metadata."""
     # Always operate on a copy of the input notebook
     nb = deepcopy(nb)

--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -338,7 +338,7 @@ def clean_notebook(nb, clear_outputs):
                 cell["metadata"].pop("id")
 
         if cell["cell_type"] == "code":
-            # Remove code cell outputs only in notebooks under tutorials
+            # Remove code cell outputs if requested
             if clear_outputs:
                 cell["outputs"] = []
 

--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -486,7 +486,7 @@ def add_kaggle_badge(cell):
         service = "https://kaggle.com/kernels/welcome?src="
         local_path = re.findall(r'(tutorials.+?\.ipynb)', cell_text)[0]
         a = f'"<a href=\"{service}https://raw.githubusercontent.com/NeuromatchAcademy/{REPO}/{MAIN_BRANCH}/{local_path}\" target=\"_parent\"><img src=\"{badge_link}\" alt=\"Open in Kaggle\"/></a>"'
-        cell["source"] = [cell_text, a]
+        cell["source"] = cell_text, a
  
 def sequentially_executed(nb):
     """Return True if notebook appears freshly executed from top-to-bottom."""

--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -126,7 +126,7 @@ def main(arglist):
             if has_colab_badge(cell):
                 redirect_colab_badge_to_main_branch(cell)
                 # add kaggle badge
-                cell = add_kaggle_badge(cell)
+                add_kaggle_badge(cell)
 
         # Ensure that Colab metadata dict exists and enforce some settings
         add_colab_metadata(nb, nb_name)
@@ -488,8 +488,7 @@ def add_kaggle_badge(cell):
         alter = "Open in Kaggle"
         basic_url = "https://raw.githubusercontent.com/NeuromatchAcademy"
         a = f'"<a href=\"{service}{basic_url}/{REPO}/{MAIN_BRANCH}/{local_path}\" target=\"_parent\"><img src=\"{badge_link}\" alt=\"{alter}\"/></a>"'
-        cell = {"source": [cell_text, a]}
-        return cell
+        cell["source"] += f', {a}'
  
 def sequentially_executed(nb):
     """Return True if notebook appears freshly executed from top-to-bottom."""

--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -202,7 +202,7 @@ def main(arglist):
         # Clean the original notebook and save it to disk
         print(f"Writing complete notebook to {nb_path}")
         with open(nb_path, "w") as f:
-            nb_clean = clean_notebook(nb)
+            nb_clean = clean_notebook(nb, flag='projects')
             nbformat.write(nb_clean, f)
 
     exit(errors)
@@ -325,7 +325,7 @@ def extract_solutions(nb, nb_dir, nb_name):
     return nb, static_images, solution_snippets
 
 
-def clean_notebook(nb):
+def clean_notebook(nb, flag='tutorials'):
     """Remove cell outputs and most unimportant metadata."""
     # Always operate on a copy of the input notebook
     nb = deepcopy(nb)
@@ -362,9 +362,10 @@ def clean_notebook(nb):
                 cell["metadata"].pop("id")
 
         if cell["cell_type"] == "code":
-
-            # Remove code cell outputs
-            cell["outputs"] = []
+            
+            if flag == 'tutorials':
+                # Remove code cell outputs
+                cell["outputs"] = []
 
             # Ensure that form cells are hidden by default
             first_line, *_ = cell["source"].splitlines()

--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -114,15 +114,8 @@ def main(arglist):
     if errors or args.check_only:
         exit(errors)
 
-    # Further filter the notebooks to run post-processing only on tutorials and projects
-    tuts_projs = {
-        nb_path: nb
-        for nb_path, nb in notebooks.items()
-        if nb_path.startswith("tutorials") or nb_path.startswith("projects")
-    }
-
-    # Post-process notebooks to remove solution code and write both versions
-    for nb_path, nb in tuts_projs.items():
+    # Post-process notebooks
+    for nb_path, nb in notebooks.items():
 
         # Extract components of the notebook path
         nb_dir, nb_fname = os.path.split(nb_path)
@@ -136,7 +129,7 @@ def main(arglist):
         # Ensure that Colab metadata dict exists and enforce some settings
         add_colab_metadata(nb, nb_name)
 
-         # Write the original notebook back to disk, clearing outputs only for tutorials
+        # Write the original notebook back to disk, clearing outputs only for tutorials
         print(f"Writing complete notebook to {nb_path}")
         with open(nb_path, "w") as f:
             nb_clean = clean_notebook(nb, clear_outputs=nb_path.startswith("tutorials"))

--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -481,12 +481,14 @@ def test_redirect_colab_badge_to_student_version():
 def add_kaggle_badge(cell):
     """Add a kaggle badge if not exists."""
     cell_text = cell["source"]
-    if "Kaggle" not in cell_text:
+    if "kaggle" not in cell_text:
         badge_link = "https://kaggle.com/static/images/open-in-kaggle.svg"
         service = "https://kaggle.com/kernels/welcome?src="
         local_path = re.findall(r'(tutorials.+?\.ipynb)', cell_text)[0]
-        a = f'"<a href=\"{service}https://raw.githubusercontent.com/NeuromatchAcademy/{REPO}/{MAIN_BRANCH}/{local_path}\" target=\"_parent\"><img src=\"{badge_link}\" alt=\"Open in Kaggle\"/></a>"'
-        cell["source"] = cell_text, a
+        alter = "Open in Kaggle"
+        basic_url = "https://raw.githubusercontent.com/NeuromatchAcademy"
+        a = f'"<a href=\"{service}{basic_url}/{REPO}/{MAIN_BRANCH}/{local_path}\" target=\"_parent\"><img src=\"{badge_link}\" alt=\"{alter}\"/></a>"'
+        cell = {"source": [cell_text, a]}
  
 def sequentially_executed(nb):
     """Return True if notebook appears freshly executed from top-to-bottom."""

--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -126,7 +126,7 @@ def main(arglist):
             if has_colab_badge(cell):
                 redirect_colab_badge_to_main_branch(cell)
                 # add kaggle badge
-                add_kaggle_badge(cell)
+                cell = add_kaggle_badge(cell)
 
         # Ensure that Colab metadata dict exists and enforce some settings
         add_colab_metadata(nb, nb_name)
@@ -489,6 +489,7 @@ def add_kaggle_badge(cell):
         basic_url = "https://raw.githubusercontent.com/NeuromatchAcademy"
         a = f'"<a href=\"{service}{basic_url}/{REPO}/{MAIN_BRANCH}/{local_path}\" target=\"_parent\"><img src=\"{badge_link}\" alt=\"{alter}\"/></a>"'
         cell = {"source": [cell_text, a]}
+        return cell
  
 def sequentially_executed(nb):
     """Return True if notebook appears freshly executed from top-to-bottom."""

--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -485,9 +485,9 @@ def add_kaggle_badge(cell):
         badge_link = "https://kaggle.com/static/images/open-in-kaggle.svg"
         service = "https://kaggle.com/kernels/welcome?src="
         local_path = re.findall(r'(tutorials.+?\.ipynb)', cell_text)[0]
-        a = f"[![Kaggle]({badge_link})]({service}https://raw.githubusercontent.com/NeuromatchAcademy/{REPO}/{MAIN_BRANCH}/{local_path})"
-        cell["source"] += f",{a}"
-    
+        a = f'"<a href=\"{service}https://raw.githubusercontent.com/NeuromatchAcademy/{REPO}/{MAIN_BRANCH}/{local_path}\" target=\"_parent\"><img src=\"{badge_link}\" alt=\"Open in Kaggle\"/></a>"'
+        cell["source"] = [cell_text, a]
+ 
 def sequentially_executed(nb):
     """Return True if notebook appears freshly executed from top-to-bottom."""
     exec_counts = [

--- a/scripts/process_notebooks.py
+++ b/scripts/process_notebooks.py
@@ -481,12 +481,12 @@ def test_redirect_colab_badge_to_student_version():
 def add_kaggle_badge(cell):
     """Add a kaggle badge if not exists."""
     cell_text = cell["source"]
-    if len(cell_text) == 1:
+    if "Kaggle" not in cell_text:
         badge_link = "https://kaggle.com/static/images/open-in-kaggle.svg"
         service = "https://kaggle.com/kernels/welcome?src="
         local_path = re.findall(r'(tutorials.+?\.ipynb)', cell_text)[0]
         a = f"[![Kaggle]({badge_link})]({service}https://raw.githubusercontent.com/NeuromatchAcademy/{REPO}/{MAIN_BRANCH}/{local_path})"
-        cell_text.append(a)
+        cell["source"] += f",{a}"
     
 def sequentially_executed(nb):
     """Return True if notebook appears freshly executed from top-to-bottom."""


### PR DESCRIPTION
Noticed that if projects are not post-processed via ci, they do not render or they lead to an error during jupyterbook generation. Also, as students look at the project notebooks to decide, is better not to remove the outputs, so that they will be shown in the book. If we force the book workflow to execute the project notebooks then the workflow runs for a long time

1. Added in tutorials all notebooks in `tutorials` and in `projects` and renamed as `tuts_projs`.
2. Add an extra argument in `clean_notebooks` to remove outputs if the `flag==tutorials`

@mwaskom I do not know if this implementation is against the standards, so please revise as you want.

I have tested it with both tutorial notebooks and project notebooks and works